### PR TITLE
Use camelCase instead of spinal-case to separate multiple words in BEM

### DIFF
--- a/css.md
+++ b/css.md
@@ -21,9 +21,9 @@ The CSS class names we use look like this:
 * Block names always start with a capital letter.
 * Two underscores are used to adjoin an element.
 * Two hyphens are used to adjoin a modifier.
-* A single hyphen (spinal case) is used to separate multiple words
+* Camel case is used to separate multiple words
   within block, element, and modifier names.
-  e.g., `Block-name__element-name--modifier-name`
+  e.g., `Block-name__elementName--modifierName`
 * Elements may have their own modifiers.
   e.g., `Block__element--modifier`
 


### PR DESCRIPTION
As far as I can tell, the spinal-case recommendation wasn't given much discussion. I'd voiced a weak recommendation for spinal case because `this-sort-of-thing` seems easier to read than `thisSortOfThing`.

However, earlier today @VinSpee pointed out that namespacing is easier to identify in `ThisBlock--thisModifier` than `This-block--this-modifier`, which feels like a much  more important consideration.

How do y'all feel about changing this recommendation?

/Cc @brenna, @ryanto, @samselikoff 