### PR TITLE
CSS media queries should be arranged in a "mobile first" style

### DIFF
--- a/css.md
+++ b/css.md
@@ -62,6 +62,26 @@ Though it's best to stick with BEM in most cases to avoid style conflicts, gloab
 }
 ```
 
+## "Mobile first" media query arrangements
+
+Base CSS should be written for the smallest screens. Media queries should be used to introduce modified styles for progressively larger screens:
+
+```css
+.Block   { padding: 10px; }
+
+@media all and (min-width: 600px) {
+  .Block { padding: 20px; }
+}
+
+@media all and (min-width: 900px) {
+  .Block { padding: 40px; }
+}
+
+@media all and (min-width: 1200px) {
+  .Block { padding: 60px; }
+}
+```
+
 ## Organize code by class, not breakpoint
 
 In general, organize your code by classes, and put media queries within those classes:

--- a/css.md
+++ b/css.md
@@ -64,21 +64,23 @@ Though it's best to stick with BEM in most cases to avoid style conflicts, gloab
 
 ## "Mobile first" media query arrangements
 
-Base CSS should be written for the smallest screens. Media queries should be used to introduce modified styles for progressively larger screens:
+Base styles should be written for the smallest screens. Media queries should be used to introduce modified styles for progressively larger screens:
 
-```css
-.Block   { padding: 10px; }
+```sass
+.Block {
+  padding: 10px;
 
-@media all and (min-width: 600px) {
-  .Block { padding: 20px; }
-}
+  @media all and (min-width: 600px) {
+    padding: 20px;
+  }
 
-@media all and (min-width: 900px) {
-  .Block { padding: 40px; }
-}
+  @media all and (min-width: 900px) {
+    padding: 40px;
+  }
 
-@media all and (min-width: 1200px) {
-  .Block { padding: 60px; }
+  @media all and (min-width: 1200px) {
+    padding: 60px;
+  }
 }
 ```
 


### PR DESCRIPTION
I don't expect this one to be too controversial: it's one of those things we've always done but never thought to express as a rule.

> ## "Mobile first" media query arrangements
> 
> Base CSS should be written for the smallest screens. Media queries should be used to introduce modified styles for progressively larger screens:
> 
> ```css
> .Block { padding: 10px; }
> 
> @media all and (min-width: 600px) {
>   .Block { padding: 20px; }
> }
> 
> @media all and (min-width: 900px) {
>   .Block { padding: 40px; }
> }
> 
> @media all and (min-width: 1200px) {
>   .Block { padding: 60px; }
> }
> ```

The smallest screens are typically paired with the weakest processors and network speeds, and this rule means those devices have to do less work to compute CSS, and has potential future benefits like media-specific file-splitting in HTTP/2.