### PR TITLE
allow methods of up to 25 lines

### DIFF
--- a/linters/rubocop/rubocop.yml
+++ b/linters/rubocop/rubocop.yml
@@ -37,7 +37,7 @@ Metrics/LineLength:
 
 
 Metrics/MethodLength:
-  Max: 10
+  Max: 25
   Severity: refactor
 
 


### PR DESCRIPTION
@tedconf/backenders this is a question as much as a PR...

i get that we don't want hundred-line methods. that said, a 10-line limit feels overly-restrictive to me. i've tried to refactor to this limit several times and ended up feeling like the result was actually harder to understand.

  1. more context switches are required to follow one logical operation through multiple short methods
  1. requires artificially-named methods, for these methods which are only single-use and exist only to be short.
  1. lots of these tiny methods pollute the class api and make it harder to understand. (you can sorta mitigate this by making all those teensy methods private, but then you can't test them.)

all this is just to say i know there's such a thing as too long, but after trying multiple times i'm also convinced there's such a thing as too short - and 10 lines feels too short sometimes.

i'm open to picking another limit if anyone wants to suggest one.

  1. not less than 15-20
  1. not more than 50

opinions? 25 feels pretty ok to me.