### PR TITLE
ignore style problems in generated protobuf classes.

### DIFF
--- a/linters/rubocop/rubocop.yml
+++ b/linters/rubocop/rubocop.yml
@@ -8,6 +8,7 @@ AllCops:
     - 'bin/*'
     - 'spec/dummy/db/schema.rb'
     - 'spec/dummy/bin/*'
+    - 'app/models/protobuf/**/*'
 
 # codifying current rubocop defaults
 # establish our own baseline in case the project's defaults are changed


### PR DESCRIPTION
@tedconf/backenders any objections?

this is a really simple one. protobuf classes are [generated](https://github.com/tedconf/protobuf-schemas/blob/master/Rakefile) and copied into our projects.

we'll package and release them as a gem at some point, but we're not there yet. in the meantime, it's pointless to hear about style errors in generated files.