### PR TITLE
don't require top-level class comments for migration classes

### DIFF
--- a/linters/rubocop/rubocop.yml
+++ b/linters/rubocop/rubocop.yml
@@ -92,6 +92,15 @@ Style/ClosingParenthesisIndentation:
 
 
 
+# comments explaining the purpose of a class are a good thing.
+# but they're unecessary for migration classes. the purpose of a migration
+# is obvious.
+Style/Documentation:
+  Exclude:
+    - 'db/migrate/*'
+
+
+
 # it's ok to do this when it makes the code feel less crowded.
 #
 # example:


### PR DESCRIPTION
i'm a big fan of class-level "what is this for?" comments. but they're unnecessary for migrations.

@tedconf/backenders thoughts?