### PR TITLE
don't require class comments for dummy appplications

### DIFF
--- a/linters/rubocop/rubocop.yml
+++ b/linters/rubocop/rubocop.yml
@@ -93,11 +93,14 @@ Style/ClosingParenthesisIndentation:
 
 
 # comments explaining the purpose of a class are a good thing.
-# but they're unecessary for migration classes. the purpose of a migration
-# is obvious.
+# but they're unecessary in a few cases:
+#
+#   - migration classes. the purpose of a migration is obvious.
+#   - classes in a dummy application.
 Style/Documentation:
   Exclude:
     - 'db/migrate/*'
+    - 'spec/dummy/**/*'
 
 
 


### PR DESCRIPTION
'dummy applications' are generated to facilitate testing of a rails engine. they are only part of the test suite and are not packaged/shipped with the engine itself. no clients ever see them and they need not be documented.

cc @tedconf/backenders any objections?