### PR TITLE
rubocop: indent `when` 1 step (relative to `case`.)

### DIFF
--- a/linters/rubocop/rubocop.yml
+++ b/linters/rubocop/rubocop.yml
@@ -75,6 +75,22 @@ Style/BlockDelimiters:
 
 
 
+# yes:
+#   out = case subject
+#           when 1 then 'a'
+#           when 2 then 'b'
+#         end
+#
+# no:
+#   out = case subject
+#         when 1 then 'a'
+#         when 2 then 'b'
+#         end
+Style/CaseIndentation:
+  IndentOneStep: true
+
+
+
 # Style/ClosingParenthesisIndentation
 # "Align ) with ("
 #


### PR DESCRIPTION
@tedconf/backenders imo, the following indentation makes the `case` easier to read

```ruby
WaitingRoom.logger.level = case Rails.env
                             when 'development' then Logger::DEBUG
                             when 'staging'     then Logger::INFO
                             else Logger::WARN
                           end
```

when compared to this (which our current style guide enforces)

```ruby
WaitingRoom.logger.level = case Rails.env
                           when 'development' then Logger::DEBUG
                           when 'staging'     then Logger::INFO
                           else Logger::WARN
                           end
```

would like to hear thumbs up/down from as many of you as possible. will drop it if i'm alone on this.