### PR TITLE
rubocop: don't require `if` to be at the end of a single-line condition

### DIFF
--- a/linters/rubocop/rubocop.yml
+++ b/linters/rubocop/rubocop.yml
@@ -131,6 +131,18 @@ Style/EmptyLinesAroundModuleBody:
 
 
 
+# Either of these are ok
+#
+#   if foo
+#     bar
+#   end
+#
+#   bar if foo
+Style/IfUnlessModifier:
+  Enabled: false
+
+
+
 # "Style/Lambda: Use the lambda method for multi-line lambdas."
 #
 # multi-line lambdas using curly-brace syntax come up in a few places:


### PR DESCRIPTION
sometimes this style is perfect. but sometimes it breaks the flow and makes skimming code harder.

i would prefer that i not be forced to refactor code like this when it seems more readable than the single-line alternative.

```ruby
if foo
  bar
end
```

@tedconf/backenders opinions? thumbs up/down?