### PR TITLE
Disable too-many-lines-in-a-block for specs.

### DIFF
--- a/linters/rubocop/rubocop.yml
+++ b/linters/rubocop/rubocop.yml
@@ -178,6 +178,15 @@ Style/NegatedIf:
 #     RSpec.describe User do
 #       # All your specs go in here.
 #     end
+#
+# Same goes for routes - those blocks can get pretty long.
+# Borrowed from https://github.com/NobodysNightmare/rubocop/commit/99124543155b728b495560ab9e2a88ff597e1899#diff-e93280b3b31a6438c533a5f3232340d8R1179
 Metrics/BlockLength:
-  Exclude:
-    - 'spec/**/*'
+  ExcludedMethods:
+    - context
+    - describe
+    - it
+    - shared_examples
+    - shared_examples_for
+    - namespace
+    - draw

--- a/linters/rubocop/rubocop.yml
+++ b/linters/rubocop/rubocop.yml
@@ -168,3 +168,16 @@ Style/Lambda:
 # one depending on what the rest of y'all think.
 Style/NegatedIf:
   Enabled: false
+
+
+
+# Having a lot of code in a block is probably not a great thing.  But in specs,
+# it's actually great, because spec frameworks like RSpec use blocks to define
+# scopes of specs. It seems like specs are not what this rule was aimed at.
+#
+#     RSpec.describe User do
+#       # All your specs go in here.
+#     end
+Metrics/BlockLength:
+  Exclude:
+    - 'spec/**/*'


### PR DESCRIPTION
[Original flowdock thread](https://www.flowdock.com/app/ted/ruby-and-rails/threads/TS2ISqNA6_YMwuL9MWbYZfMYJE1)

So we can have plenty of coverage in blocks like these:

    RSpec.describe User do
      describe '#name' do
        context 'in some situation' do
          it 'behaves like...' do
          end
        end
      end
    end

Some examples where I've run afoul of this rule, I think unjustly (all from PageBuilder, of course):
* [the Page model spec](https://github.com/tedconf/page_builder/blob/master/spec/models/page_spec.rb)
* [the Section model spec](https://github.com/tedconf/page_builder/blob/master/spec/models/section_spec.rb)
* [the PageDuplicator spec](https://github.com/tedconf/page_builder/blob/master/spec/lib/page_duplicator_spec.rb)
* [the ThreeSisters spec](https://github.com/tedconf/page_builder/blob/master/spec/lib/three_sisters_spec.rb) (don't ask, I don't know why it's named that)
* [the PublishNoticeMailer spec](https://github.com/tedconf/page_builder/blob/master/spec/mailers/publish_notice_mailer_spec.rb)