### PR TITLE
Introduce recommendations for EditorConfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,18 @@
+# Please use EditorConfig:
+# http://EditorConfig.org
+
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 2
+
+[*.{diff,md}]
+trim_trailing_whitespace = false
+
+[*.hbs]
+insert_final_newline = false

--- a/linters/editorconfig/README.md
+++ b/linters/editorconfig/README.md
@@ -1,0 +1,13 @@
+# Common EditorConfig configuration for TED projects
+
+It's recommended that every code project include an `.editorconfig` file and that every developer configure their text editor or IDE to [use EditorConfig.](https://editorconfig.org/#download)
+
+## Goals
+
+[EditorConfig](https://editorconfig.org) helps developers define and maintain consistent coding styles between different editors and IDEs. While other linters handle language-specific concerns, EditorConfig manages near-universal plain text concerns such as character encoding and line endings and other whitespace. Normalizing these improves readability/maintainability and avoids corruption issues (e.g. with unexpected encodings).
+
+## Usage
+
+Copy this repository's [`.editorconfig`](../../.editorconfig) to your project's root.
+
+[Install and configure an EditorConfig plugin for your preferred text editor or IDE.](https://editorconfig.org/#download)


### PR DESCRIPTION
This PR introduces an `.editorconfig` to this repository's root, serving as both the project's configuration file and as a general recommendation for other projects (per #56).

For the most part, the included `.editorconfig` adheres to configurations we've long used in TED's projects, with the following additions:

* Do not trim trailing whitespace from .diff files, per ember-cli/ember-cli@ff373f8
* Do not trim trailing whitespace from .md files since ending a line in two spaces has semantic meaning in MarkDown (indicating a newline)
* Do not insert a final newline into .hbs files, per ember-cli/ember-cli#3738 this causes unwanted text nodes in HTMLBars
* Insert a newline elsewhere because it's handy for Vi/Vim