### PR TITLE
rubocop: enable Lint/UselessAssignment

### DIFF
--- a/linters/rubocop/rubocop.yml
+++ b/linters/rubocop/rubocop.yml
@@ -262,3 +262,8 @@ Style/SignalException:
   Enabled: true
   EnforcedStyle: only_raise
   Severity: warning
+
+# point out assignments to unused variables
+Lint/UselessAssignment:
+  Enabled: true
+  Severity: refactor


### PR DESCRIPTION
@tedconf/backenders i think this one has been useful in the past. pointed out to me some places where my code was doing unneeded/forgotten work.

any objections?

```
spec/models/video_spec.rb:564:7: R: Lint/UselessAssignment: Useless assignment to variable - unexpected.
      unexpected = build(:video, :with_primary_audio_language_code)
      ^^^^^^^^^^
```