### PR TITLE
Exclude node_modules and bower_components

### DIFF
--- a/linters/rubocop/rubocop.yml
+++ b/linters/rubocop/rubocop.yml
@@ -13,6 +13,8 @@ AllCops:
     - 'spec/dummy/db/schema.rb'
     - 'spec/dummy/bin/*'
     - 'app/models/protobuf/**/*'
+    - 'node_modules/**/*'
+    - 'bower_components/**/*'
 
 # DRY your Gemfile
 Bundler/DuplicatedGem:


### PR DESCRIPTION
rubocop will attempt to lint files that appear in these directories with names it thinks are Ruby.  

Example:
```
bower_components/backbone.syphon/Gemfile:4:1: W: Bundler/OrderedGems: Gems should be sorted in an alphabetical order 

node_modules/gulp-sass/node_modules/node-sass/src/libsass/contrib/libsass.spec:1:5: E: Lint/Syntax: unexpected token tCOLON
(Using Ruby 2.3 parser; configure using TargetRubyVersion parameter, under AllCops)
```

This will become more commonplace as webpacker/yarn are used.