### PR TITLE
Fix Access Modifier indent intent

### DIFF
--- a/linters/rubocop/rubocop.yml
+++ b/linters/rubocop/rubocop.yml
@@ -168,6 +168,11 @@ Style/HashSyntax:
   Enabled: true
   Severity: warning
 
+# Indent consistently, who doesn't like that?
+Layout/IndentationConsistency:
+  Enabled: true
+  Severity: warning
+
 # Two spaces, no tabs (for indentation).
 Layout/IndentationWidth:
   Enabled: true

--- a/linters/rubocop/rubocop.yml
+++ b/linters/rubocop/rubocop.yml
@@ -168,13 +168,6 @@ Style/HashSyntax:
   Enabled: true
   Severity: warning
 
-# Method definitions after `private` or `protected` isolated calls need one
-# extra level of indentation.
-Layout/IndentationConsistency:
-  Enabled: true
-  EnforcedStyle: rails
-  Severity: warning
-
 # Two spaces, no tabs (for indentation).
 Layout/IndentationWidth:
   Enabled: true


### PR DESCRIPTION
This cop was included in an accidental form by yours truly.

(I think) Most of our projects use the [default Layout/AccessModifierIndentation of indent](https://github.com/bbatsov/rubocop/blob/ca92235edb6520fc62d7a5d81224fb4cce8d689b/lib/rubocop/cop/layout/access_modifier_indentation.rb#L6-L36) which puts method definitions at the same level of indent, which was my intent.  I didn't want to cause churn in indenting beneath that.

```ruby
#good
class Foo
  private

  def dancer
  end
end

#bad
class Foo
private

  def investigation
  end
end

#bad
class Foo
  private

    def black_site_interrogation
    end
end
```

@tedconf/backenders can I get a 👍 👎 ?