### PR TITLE
Permit long blocks in FactoryBot.define methods

### DIFF
--- a/linters/rubocop/rubocop.yml
+++ b/linters/rubocop/rubocop.yml
@@ -108,6 +108,7 @@ Metrics/BlockLength:
     - shared_examples_for
     - namespace
     - draw
+    - define # for FactoryBot
 
 # cribbed from https://github.com/rails/rails/blob/1f7f872ac6c8b57af6e0117bde5f6c38d0bae923/.rubocop.yml
 


### PR DESCRIPTION
@tedconf/backenders I'm starting to lean more on FactoryBot in RoadRunner, and with that gem, everything happens inside a `FactoryBot.define` block. Another DSL, another place we should probably disable a "too-many lines" cop. Thoughts?