### PR TITLE
Permit long blocks in FactoryBot's `#factory` calls

### DIFF
--- a/linters/rubocop/rubocop.yml
+++ b/linters/rubocop/rubocop.yml
@@ -109,6 +109,7 @@ Metrics/BlockLength:
     - namespace
     - draw
     - define # for FactoryBot
+    - factory # for FactoryBot
 
 # cribbed from https://github.com/rails/rails/blob/1f7f872ac6c8b57af6e0117bde5f6c38d0bae923/.rubocop.yml
 


### PR DESCRIPTION
@tedconf/backenders following on from https://github.com/tedconf/code-style-guides/pull/65, I think we should disable Metrics/BlockLength for FactoryBot's `factory` methods. Thoughts?