### PR TITLE
eslint-config: Add eslint-plugin-eslint-comments

### DIFF
--- a/linters/eslint/eslint-config/index.js
+++ b/linters/eslint/eslint-config/index.js
@@ -4,11 +4,10 @@ module.exports = {
     'eslint-config-prettier',
     'eslint-config-prettier/babel',
     'eslint-config-prettier/react',
+    'plugin:eslint-comments/recommended',
   ].map(require.resolve),
 
-  plugins: [
-    'react-hooks',
-  ],
+  plugins: ['react-hooks'],
 
   rules: {
     'react-hooks/rules-of-hooks': 'error',

--- a/linters/eslint/eslint-config/package.json
+++ b/linters/eslint/eslint-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tedconf/eslint-config",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Shared eslint config for TED projects",
   "main": "index.js",
   "author": "Matt LaForest<mattl@ted.com>",
@@ -10,6 +10,7 @@
     "eslint": "^5",
     "eslint-config-airbnb": "^17",
     "eslint-config-prettier": "^4",
+    "eslint-plugin-eslint-comments": "^3.1.2",
     "eslint-plugin-import": "^2.14.0",
     "eslint-plugin-jsx-a11y": "^6.1.1",
     "eslint-plugin-prettier": "^3.0.1",
@@ -21,6 +22,7 @@
     "eslint": "5.3.0",
     "eslint-config-airbnb": "17.1.0",
     "eslint-config-prettier": "^4.1.0",
+    "eslint-plugin-eslint-comments": "^3.1.2",
     "eslint-plugin-import": "^2.14.0",
     "eslint-plugin-jsx-a11y": "^6.1.1",
     "eslint-plugin-prettier": "^3.0.1",

--- a/linters/eslint/eslint-config/yarn.lock
+++ b/linters/eslint/eslint-config/yarn.lock
@@ -328,6 +328,14 @@ eslint-module-utils@^2.3.0:
     debug "^2.6.8"
     pkg-dir "^2.0.0"
 
+eslint-plugin-eslint-comments@^3.1.2:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-eslint-comments/-/eslint-plugin-eslint-comments-3.1.2.tgz#4ef6c488dbe06aa1627fea107b3e5d059fc8a395"
+  integrity sha512-QexaqrNeteFfRTad96W+Vi4Zj1KFbkHHNMMaHZEYcovKav6gdomyGzaxSDSL3GoIyUOo078wRAdYlu1caiauIQ==
+  dependencies:
+    escape-string-regexp "^1.0.5"
+    ignore "^5.0.5"
+
 eslint-plugin-import@^2.14.0:
   version "2.16.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.16.0.tgz#97ac3e75d0791c4fac0e15ef388510217be7f66f"
@@ -632,6 +640,11 @@ ignore@^4.0.2:
   version "4.0.6"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-4.0.6.tgz#750e3db5862087b4737ebac8207ffd1ef27b25fc"
   integrity sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==
+
+ignore@^5.0.5:
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.1.2.tgz#e28e584d43ad7e92f96995019cc43b9e1ac49558"
+  integrity sha512-vdqWBp7MyzdmHkkRWV5nY+PfGRbYbahfuvsBCh277tq+w9zyNi7h5CYJCK0kmzti9kU+O/cB7sE8HvKv6aXAKQ==
 
 imurmurhash@^0.1.4:
   version "0.1.4"


### PR DESCRIPTION
# What this does
Adds the eslint-comments plugin to our base config. This helps us avoid problems that come with disabling eslint completely masking violations that could cause actual errors.

# Note
This is based on the react hooks branch, and should have its based changed to master after that is merged.