### PR TITLE
rename cop to fix "Error: The `Style/UnneededPercentQ` cop has been r…

### DIFF
--- a/linters/rubocop/rubocop.yml
+++ b/linters/rubocop/rubocop.yml
@@ -256,7 +256,7 @@ Layout/TrailingWhitespace:
   Severity: warning
 
 # Use quotes for string literals when they are enough.
-Style/UnneededPercentQ:
+Style/RedundantPercentQ:
   Enabled: true
   Severity: warning
 


### PR DESCRIPTION
…enamed to `Style/RedundantPercentQ`."

Breaking change was introduced here: https://github.com/rubocop-hq/rubocop/issues/7077