### PR TITLE
Bump rubocop to 0.91

### DIFF
--- a/gem/ted_rubocop_rules.gemspec
+++ b/gem/ted_rubocop_rules.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   # Specify which files should be added to the gem when it is released.
   spec.files         = ["rubocop.yml", "lib/ted_rubocop_rules/version.rb"]
 
-  spec.add_dependency "rubocop", "= 0.86.0"
+  spec.add_dependency "rubocop", "= 0.91.0"
   spec.add_development_dependency "bundler", "~> 1.17"
   spec.add_development_dependency "rake", "~> 13.0"
 end


### PR DESCRIPTION
As of 2020-09-21, we're pinned to `rubocop` 0.86.0.  That version
picks up `rubocop-ast` 0.4.2, which throws errors on `Layout/LineLength`.

Upgrading rubocop to 0.90 or above seems to fix things.

https://github.com/rubocop-hq/rubocop-ast/issues/113

https://github.com/rubocop-hq/rubocop/issues/8713